### PR TITLE
test modulo sales planning

### DIFF
--- a/cypress/e2e/sales_plan/create_plan.cy.js
+++ b/cypress/e2e/sales_plan/create_plan.cy.js
@@ -1,0 +1,55 @@
+import {BASE_URL, USERNAME, PASSWORD} from '../../support/constants'
+
+describe('Products table', () => {
+    beforeEach(() => {
+        cy.visit(BASE_URL);
+        cy.get('input[type="text"').first().type(USERNAME);
+        cy.get('input[type="password"').first().type(PASSWORD);
+        cy.get('[data-testid="loginButton"]').click();
+        cy.url().should('match', /\/products$/);
+        cy.wait(1000);
+        cy.get('a[href="/sales"]').click();
+        cy.url().should('include', '/sales');
+        cy.wait(1000);
+        cy.contains('button', 'Sales Plan').click();
+    })
+
+    it('should display the create sales plan form', () => {
+        cy.contains('Create sales plan').should('be.visible');
+        cy.contains('Create a sales plan for a seller').should('be.visible');
+        cy.get('form').should('exist');
+    });
+
+    it('should close the form when cancel is clicked', () => {
+        cy.contains('CANCEL').click();
+        cy.contains('Create sales plan').should('not.exist');
+    });
+
+    it('should allow entering data in all fields', () => {
+        cy.get('div[title="Fabricante del producto"]').click();
+        cy.get('ul[role="listbox"] li').then($options => {
+           const randomIndex = Math.floor(Math.random() * $options.length);
+            cy.wrap($options[randomIndex]).click({force: true});
+        });
+        cy.get('input[name="meta_venta"]').type(Cypress._.random(10000, 1000000));
+        cy.get('input[name="productos_plan"]').type('Test product');
+    });
+
+    // it('should submit the form and show a success message', () => {
+    //     cy.get('div[title="Fabricante del producto"]').click();
+    //     cy.get('ul[role="listbox"] li').then($options => {
+    //        const randomIndex = Math.floor(Math.random() * $options.length);
+    //         cy.wrap($options[randomIndex]).click({force: true});
+    //     });
+    //     cy.get('input[name="meta_venta"]').type(Cypress._.random(10000, 1000000));
+    //     cy.get('input[name="productos_plan"]').type('Test product');
+
+    //     cy.intercept('POST', '**/vendedor/crear_plan_ventas').as('createPlan');
+
+    //     cy.get('button[type="submit"]').click();
+
+    //     cy.wait('@createPlan').its('response.statusCode').should('eq', 201);
+    //     cy.get('@createPlan').its('request.url').should('match', /\/vendedor\/crear_plan_ventas$/);
+    // });
+
+})

--- a/cypress/e2e/sales_plan/plan_table.cy.js
+++ b/cypress/e2e/sales_plan/plan_table.cy.js
@@ -1,0 +1,42 @@
+import {BASE_URL, USERNAME, PASSWORD} from '../../support/constants'
+
+describe('Products table', () => {
+    beforeEach(() => {
+        cy.visit(BASE_URL);
+        cy.get('input[type="text"').first().type(USERNAME);
+        cy.get('input[type="password"').first().type(PASSWORD);
+        cy.get('[data-testid="loginButton"]').click();
+        cy.url().should('match', /\/products$/);
+        cy.wait(1000);
+        cy.get('a[href="/sales"]').click();
+        cy.url().should('include', '/sales');
+        cy.wait(1000);
+    })
+
+    it('should display the sales plan table with correct columns', () => {
+        cy.contains('ID').should('be.visible');
+        cy.contains('Status').should('be.visible');
+        cy.contains('Creation Date').should('be.visible');
+        cy.contains('End Date').should('be.visible');
+        cy.contains('Goal').should('be.visible');
+        cy.contains('Products').should('be.visible');
+        cy.contains('Close').should('be.visible');
+    });
+
+    // it('should display at least one sales plan row', () => {
+    //     cy.wait(1000);
+    //     cy.get('.MuiDataGrid-row').should('have.length.greaterThan', 0);
+    // });
+
+    it('should open the column menu on hover and click for each column', () => {
+        cy.get('.MuiDataGrid-columnHeader').each(($header) => {
+            cy.wrap($header)
+                .trigger('mouseover')
+                .find('.MuiDataGrid-menuIconButton, .MuiDataGrid-menuIcon button')
+                .click({ force: true });
+            cy.get('.MuiPopover-root, [role="menu"]').should('exist');
+            cy.get('body').type('{esc}');
+        });
+    });
+
+})


### PR DESCRIPTION
This pull request adds new Cypress end-to-end tests for the sales plan feature, focusing on creating a sales plan and verifying the sales plan table. The tests include basic UI validations and interactions, with some test cases commented out for future implementation.

### New Cypress Tests for Sales Plan Feature:

#### Create Sales Plan Tests (`create_plan.cy.js`):
* Added tests to verify the visibility of the "Create sales plan" form and its fields.
* Implemented tests for interacting with form fields, including selecting a product manufacturer, entering sales goals, and adding products to the plan.
* Commented out a test for form submission and success message validation, which includes intercepting the API request.

#### Sales Plan Table Tests (`plan_table.cy.js`):
* Added tests to verify the visibility of key columns in the sales plan table, such as "ID," "Status," and "Goal."
* Implemented a test for opening the column menu on hover and click for each column header.
* Commented out a test to check for the presence of at least one sales plan row in the table.